### PR TITLE
Test build.xml: add explicit java 1.8 target for javac

### DIFF
--- a/tests/build.xml
+++ b/tests/build.xml
@@ -76,7 +76,7 @@
 
   <target name="compile" depends="init">
     <javac srcdir="${testsrc.dir}" destdir="${testbuild.dir}" debug="true"
-	includeantruntime="yes">
+	includeantruntime="yes" source="1.8" target="1.8">
 	<classpath>
           <path refid="cp.compile" />
 	</classpath>


### PR DESCRIPTION
Enable different java versions in build environemnt by setting explicit required 1.8 for IOT test cases because they use Java 8 lambda expressions.