### PR TITLE
Subscribe to JSON commands

### DIFF
--- a/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson/devicesubscribe.spl
+++ b/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson/devicesubscribe.spl
@@ -1,6 +1,6 @@
 /*
 # Licensed Materials - Property of IBM
-# Copyright IBM Corp. 2016
+# Copyright IBM Corp. 2017
  */
 
 namespace com.ibm.streamsx.iot.watson;
@@ -11,7 +11,7 @@ use com.ibm.streamsx.json::JSONToTuple;
 use com.ibm.streamsx.json::Json;
 
 /**
- * Subsribes to device commands to be sent to devices for an organization.
+ * Subscribes to device commands to be sent to devices for an organization.
  *
  * Subscribes to the topic `streamsx/iot/device/commands/send`
  * with a tuple type of [DeviceCmd], or a JSON string that can be converted to a [DeviceCmd]
@@ -49,10 +49,22 @@ public composite SubscribeDeviceCommands() {
 				streamType: Json;
 		}
 
-		stream<DeviceCmd> JsonCommandTuples =
+		(stream<DeviceCmd> JsonCommandTuples ; stream<Json> errors) =
 			JSONToTuple(JsonCommands)
 		{
 		}
+
+		() as JsonParsingErrors = Custom(errors as in0)
+		{
+			logic
+				onTuple in0 :
+				{
+					appTrc(Trace.error, "Error parsing JSON command: " + errors.jsonString,
+						"JsonParsingErrors") ;
+				}
+
+		}
+
 		
       () as SendCommandsToDevice = SendCommandToDevice(CommandsToSend ,JsonCommandTuples) {
         param

--- a/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson/devicesubscribe.spl
+++ b/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson/devicesubscribe.spl
@@ -7,12 +7,14 @@ namespace com.ibm.streamsx.iot.watson;
 
 use com.ibm.streamsx.iot::*;
 use com.ibm.streamsx.topology.topic::Subscribe;
+use com.ibm.streamsx.json::JSONToTuple;
+use com.ibm.streamsx.json::Json;
 
 /**
  * Subsribes to device commands to be sent to devices for an organization.
  *
  * Subscribes to the topic `streamsx/iot/device/commands/send`
- * with a tuple type of [DeviceCmd].
+ * with a tuple type of [DeviceCmd], or a JSON string that can be converted to a [DeviceCmd]
  * 
  * @param org Organization identifier.
  * @param domain Service domain, used to define the host for the MQTT message hub host, which will be *org*`.messaging.`*domain*. Defaults to `internetofthings.ibmcloud.com` supporting IBM Watson IoT Platform hosted on Bluemix.
@@ -35,7 +37,24 @@ public composite SubscribeDeviceCommands() {
           topic: "streamsx/iot/device/commands/send";
           streamType: DeviceCmd;
       }
-      () as SendCommandsToDevice = SendCommandToDevice(CommandsToSend) {
+      
+      
+      /*
+       * Subscribe to commands sent as JSON
+       */
+      stream<Json>JsonCommands = Subscribe()
+		{
+			param
+				topic : "streamsx/iot/device/commands/send" ;
+				streamType: Json;
+		}
+
+		stream<DeviceCmd> JsonCommandTuples =
+			JSONToTuple(JsonCommands)
+		{
+		}
+		
+      () as SendCommandsToDevice = SendCommandToDevice(CommandsToSend ,JsonCommandTuples) {
         param
           org : $org;
           domain : $domain;


### PR DESCRIPTION
This would allow commands to be sent by Python applications by simply publishing a stream of JSON.