### PR TITLE
test build.xml: new test target test-full

### DIFF
--- a/tests/build.xml
+++ b/tests/build.xml
@@ -91,6 +91,23 @@
     </javac>
    </target>
 
+   <target name="test-full" depends="compile">
+      <property name="streamsx.iot.test.device.cfg" value="skip"/>
+      <junit fork="yes" printsummary="yes" haltonfailure="no" dir="${sabs}">
+         <sysproperty key="streamsx.iot.test.device.cfg" value="${streamsx.iot.test.device.cfg}"/>
+         <classpath>
+            <pathelement location="${testbuild.dir}"/>
+            <path refid="cp.compile"/>
+         </classpath>
+         <!--<formatter type="xml"/>-->
+         <formatter type="plain"/>
+         <batchtest todir="${testreports.dir}">
+            <fileset dir="${testsrc.dir}">
+               <include name="**/*Test.java"/>
+            </fileset>
+         </batchtest>
+      </junit>
+   </target>	
 
    <target name="unittests" depends="compile">
    <property name="streamsx.iot.test.device.cfg" value="skip"/>

--- a/tests/build.xml
+++ b/tests/build.xml
@@ -91,23 +91,8 @@
     </javac>
    </target>
 
-   <target name="test-full" depends="compile">
-      <property name="streamsx.iot.test.device.cfg" value="skip"/>
-      <junit fork="yes" printsummary="yes" haltonfailure="no" dir="${sabs}">
-         <sysproperty key="streamsx.iot.test.device.cfg" value="${streamsx.iot.test.device.cfg}"/>
-         <classpath>
-            <pathelement location="${testbuild.dir}"/>
-            <path refid="cp.compile"/>
-         </classpath>
-         <!--<formatter type="xml"/>-->
-         <formatter type="plain"/>
-         <batchtest todir="${testreports.dir}">
-            <fileset dir="${testsrc.dir}">
-               <include name="**/*Test.java"/>
-            </fileset>
-         </batchtest>
-      </junit>
-   </target>	
+   <target name="test-full" depends="e2etests,unittests">
+   </target>
 
    <target name="unittests" depends="compile">
    <property name="streamsx.iot.test.device.cfg" value="skip"/>


### PR DESCRIPTION
need one target, because calling t he e2etest and unittest targets from external ant script deletes reports from first executed target