### PR TITLE
Change tests: configure the toolkit used in topology

### DIFF
--- a/tests/build.xml
+++ b/tests/build.xml
@@ -4,12 +4,35 @@
 	<property environment="env"/>
 	<property name="streams.install" value="${env.STREAMS_INSTALL}"/>
 
+  <!-- *****************************************************
+       To be flexible in testing following properties are to be set
+       depending on test enviornment or test context
+
+       The default test context is the test during development.
+       The "iot.tk" 'under test' is the build one in the repository.
+       The "topology.tk" used for test is the one from the installed
+       Streams product.
+       Additional toolkits "streams.tk", which iot.tk depends on 
+       are taken also from the Streams product.
+
+       So in development environment nothing special has to be set.
+      
+      ****************************************************** -->
 	<property name="iot.tk"
 	   location="${basedir}/../com.ibm.streamsx.iot"/>
+	<property name="topology.tk"
+	   location="${streams.install}/toolkits/com.ibm.streamsx.topology"/>
 	<property name="streams.tk"
 	   location="${streams.install}/toolkits"/>
-	<property name="extra.tk"
-	   location="${env.HOME}/toolkits"/>
+
+
+   <target name="print-tklocations" >
+   <echo message="iot.tk : ${iot.tk}"/>
+   <echo message="topology.tk : ${topology.tk}"/>
+   <echo message="streams.tk : ${streams.tk}"/>
+   </target>
+
+
 	<property name="sabs"
 	   location="${basedir}/sabs"/>
 	<property name="quarks"
@@ -47,8 +70,7 @@
 
   <path id="cp.streams">
     <pathelement location="${streams.install}/lib/com.ibm.streams.operator.samples.jar" />
-    <pathelement location="${user.home}/toolkits/com.ibm.streamsx.topology/lib/com.ibm.streamsx.topology.jar" />
-    <pathelement location="${streams.install}/toolkits/com.ibm.streamsx.topology/lib/com.ibm.streamsx.topology.jar" />
+    <pathelement location="${topology.tk}/lib/com.ibm.streamsx.topology.jar" />
   </path>
 
    <path id="cp.junit">
@@ -60,13 +82,7 @@
     <path refid="cp.streams" />
     <path refid="cp.quarks" />
     <path refid="cp.junit" />
-    <pathelement location="../com.ibm.streamsx.iot/lib/com.ibm.streamsx.iot.jar" />
-    <pathelement location="../../../github/streamsx.iot/com.ibm.streamsx.iot/lib/com.ibm.streamsx.iot.jar" />
-    <!-- when called in production the toolkit will be available already in 
-         STREAMS_INSTALL environment 
-    TODO: insert printout which jar is used local or STREAMS_INSTALL
-    -->
-    <pathelement location="${streams.install}/toolkits/com.ibm.streamsx.iot/lib/com.ibm.streamsx.iot.jar" />
+    <pathelement location="${iot.tk}/lib/com.ibm.streamsx.iot.jar" />
   </path>
 
   <path id="cp.quarks">
@@ -94,11 +110,25 @@
    <target name="test-full" depends="e2etests,unittests">
    </target>
 
-   <target name="unittests" depends="compile">
+
+   <!-- *******************************************************
+        following properties are needed in this target
+        1. as systemproperties which are read by the java/topology app
+           streamsx.iot.test.device.cfg - cfg file name of IoT device cfg
+           streamsx.iot.toolkitlocation - iot toolkit under test
+        2. as environment variable 
+           STREAMS_SPLPATH - this env-var is used by topology to determine
+                             standard toolit location for tks used by
+                             iot toolkit under test
+        ******************************************************* -->
+   <target name="unittests" depends="print-tklocations,compile">
    <property name="streamsx.iot.test.device.cfg" value="skip"/>
    <junit fork="yes" printsummary="yes" haltonfailure="no" dir="${sabs}">
+     <env key="STREAMS_SPLPATH" value="${streams.tk}"/>
      <sysproperty key="streamsx.iot.test.device.cfg"
                   value="${streamsx.iot.test.device.cfg}"/>
+     <sysproperty key="streamsx.iot.toolkitlocation"
+                 value="${iot.tk}"/>
      <classpath>
          <pathelement location="${testbuild.dir}"/>
          <path refid="cp.compile"/>
@@ -120,12 +150,25 @@
    <!-- event test create an Edgent application which works as device -->
    <!-- result received by topology application is checked against    -->
    <!-- the expected values derived from Edgent sent data             -->
-   <target name="e2etests" depends="compile,submit.hubapp">
+   <!-- *******************************************************
+        following properties are needed in this task
+        1. as systemproperties which are read by the java/topology app
+           streamsx.iot.test.device.cfg - cfg file name of IoT device cfg
+           streamsx.iot.toolkitlocation - iot toolkit location under test
+        2. as environment variable 
+           STREAMS_SPLPATH - this env-var is used by topology to determine
+                             a standard toolit location for tk used by
+                             iot toolkit location under test
+        ******************************************************* -->
+   <target name="e2etests" depends="print-tklocations,compile,submit.hubapp">
       <!-- WatsonIot device-ceredentials for fix DeviceType: Test, DeviceId:Test001-->
       <property name="streamsx.iot.test.device.cfg" value="${basedir}/device.cfg"/>
       <junit fork="yes" printsummary="yes" haltonfailure="no" dir="${sabs}">
+         <env key="STREAMS_SPLPATH" value="${streams.tk}"/>
          <sysproperty key="streamsx.iot.test.device.cfg"
                      value="${streamsx.iot.test.device.cfg}"/>
+         <sysproperty key="streamsx.iot.toolkitlocation"
+                    value="${iot.tk}"/>
          <classpath>
             <pathelement location="${testbuild.dir}"/>
             <path refid="cp.compile"/>
@@ -171,6 +214,12 @@
     </target>
 
    <!-- submit SAB file by executing streamtool direct from ant -->
+   <!-- properties read from iotf.properties file defining the credentials
+        for an application acessing the Bluemix IOTF service:
+         iot.org : organzation
+         iot.authKey : application key
+         iot.authToken : application authentiocation token
+   -->
 	<macrodef name="submit.iot.app">
       <attribute name="namespace"/>
       <attribute name="composite"/>
@@ -214,7 +263,7 @@
       <sequential>
          <splcompile 
 			   mainComposite="@{namespace}::@{composite}"
-			   toolkitlocations="@{toolkit}:${iot.tk}:${extra.tk}:${streams.tk}"/>
+			   toolkitlocations="@{toolkit}:${iot.tk}:${streams.tk}"/>
          <move file="${basedir}/output/@{namespace}.@{composite}.sab"
              toDir="${sabs}"/>
          <delete dir="${basedir}/output"/>
@@ -228,7 +277,7 @@
       <sequential>
          <splcompile
             mainComposite="@{namespace}::@{composite}"
-            toolkitlocations="${iot.tk}:${extra.tk}:${streams.tk}"/>
+            toolkitlocations="${iot.tk}:${streams.tk}"/>
          <move file="${basedir}/output/@{namespace}.@{composite}.sab"
              toDir="${sabs}"/>
          <delete dir="${basedir}/output"/>

--- a/tests/src/test/java/com/ibm/streamsx/iot/test/DeviceCommandsTest.java
+++ b/tests/src/test/java/com/ibm/streamsx/iot/test/DeviceCommandsTest.java
@@ -14,6 +14,8 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import java.io.File;
+
 import com.ibm.json.java.JSON;
 import com.ibm.json.java.JSONObject;
 import com.ibm.streamsx.iot.DeviceCmd;
@@ -21,6 +23,7 @@ import com.ibm.streamsx.iot.IotStreams;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.tester.Condition;
+import com.ibm.streamsx.topology.spl.SPL;
 
 public class DeviceCommandsTest {
     
@@ -36,6 +39,10 @@ public class DeviceCommandsTest {
     private void testDeviceCmdsAll(boolean allowFilter) throws Exception {
         
         Topology topology = new Topology();
+
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+    	System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+    	SPL.addToolkit(topology, iotTkLocation);
         
         JSONObject[] commands = generateCommands(200);
         
@@ -87,6 +94,10 @@ public class DeviceCommandsTest {
     private void testDeviceCmdsCommandId(boolean allowFilter, String[] typeIds, String...cmdIds) throws Exception {
         
         Topology topology = new Topology();
+
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+    	System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+    	SPL.addToolkit(topology, iotTkLocation);
         
         JSONObject[] cmds = generateCommands(200);
         

--- a/tests/src/test/java/com/ibm/streamsx/iot/test/DeviceEventsTest.java
+++ b/tests/src/test/java/com/ibm/streamsx/iot/test/DeviceEventsTest.java
@@ -14,6 +14,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import java.io.File;
+
 import org.junit.Test;
 
 import com.ibm.json.java.JSON;
@@ -27,6 +29,7 @@ import com.ibm.streamsx.topology.context.StreamsContextFactory;
 import com.ibm.streamsx.topology.streams.StringStreams;
 import com.ibm.streamsx.topology.tester.Condition;
 import com.ibm.streamsx.topology.tester.Tester;
+import com.ibm.streamsx.topology.spl.SPL;
 
 public class DeviceEventsTest {
     
@@ -42,7 +45,11 @@ public class DeviceEventsTest {
     private void testDeviceEventsAll(boolean allowFilter) throws Exception {
         
         Topology topology = new Topology();
-        
+
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+        System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+        SPL.addToolkit(topology, iotTkLocation);
+       
         JSONObject[] events = generateEvents(200);
         
         Simulate.simulateEvents(topology, 10, allowFilter, events);
@@ -94,6 +101,10 @@ public class DeviceEventsTest {
     private void testDeviceEventsEventId(boolean allowFilter, String[] typeIds, String...eventIds) throws Exception {
         
         Topology topology = new Topology();
+  
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+    	System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+    	SPL.addToolkit(topology, iotTkLocation);
         
         JSONObject[] events = generateEvents(200);
         

--- a/tests/src/test/java/com/ibm/streamsx/iot/test/DeviceStatusTest.java
+++ b/tests/src/test/java/com/ibm/streamsx/iot/test/DeviceStatusTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import java.io.File;
+
 import org.junit.Test;
 
 import com.ibm.json.java.JSON;
@@ -18,6 +20,7 @@ import com.ibm.streamsx.iot.IotStreams;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.tester.Condition;
+import com.ibm.streamsx.topology.spl.SPL;
 
 public class DeviceStatusTest {
     
@@ -33,6 +36,10 @@ public class DeviceStatusTest {
     private void testDeviceStatussAll(boolean allowFilter) throws Exception {
         
         Topology topology = new Topology();
+
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+    	System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+    	SPL.addToolkit(topology, iotTkLocation);
         
         JSONObject[] statuses = generateStatuses(200);
         
@@ -68,6 +75,10 @@ public class DeviceStatusTest {
         
         Topology topology = new Topology();
         
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+    	System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+    	SPL.addToolkit(topology, iotTkLocation);
+
         JSONObject[] statuses = generateStatuses(200);
         
         Simulate.simulateStatuses(topology, 10, allowFilter, statuses);

--- a/tests/src/test/java/com/ibm/streamsx/iot/test/watson/WatsonDeviceCommandsTest.java
+++ b/tests/src/test/java/com/ibm/streamsx/iot/test/watson/WatsonDeviceCommandsTest.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import java.io.File;
+
 import org.junit.Test;
 
 import com.ibm.json.java.JSON;
@@ -22,13 +24,19 @@ import com.ibm.streamsx.iot.test.Simulate;
 import com.ibm.streamsx.topology.TStream;
 import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.tester.Condition;
+import com.ibm.streamsx.topology.spl.SPL;
 
 public class WatsonDeviceCommandsTest {
     
     @Test
     public void testDeviceCmdsAll() throws Exception {
                 
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+
         Topology topology = new Topology();
+        
+        System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+        SPL.addToolkit(topology, iotTkLocation);
         
         JSONObject[] commands = DeviceCommandsTest.generateCommands(20);
         
@@ -55,8 +63,13 @@ public class WatsonDeviceCommandsTest {
     @Test
     public void testDeviceCmdsFilter() throws Exception {
                 
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
+
         Topology topology = new Topology();
         
+        System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+        SPL.addToolkit(topology, iotTkLocation);
+
         JSONObject[] commands = DeviceCommandsTest.generateCommands(40);
         
         TStream<JSONObject> rawCmds = topology.constants(Arrays.asList(commands));

--- a/tests/src/test/java/com/ibm/streamsx/iot/test/watson/WatsonDeviceEventsTest.java
+++ b/tests/src/test/java/com/ibm/streamsx/iot/test/watson/WatsonDeviceEventsTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.io.File;
+
 import org.junit.Test;
 
 import com.ibm.json.java.JSON;
@@ -19,14 +21,20 @@ import com.ibm.streamsx.topology.Topology;
 import com.ibm.streamsx.topology.streams.StringStreams;
 import com.ibm.streamsx.topology.tester.Condition;
 import com.ibm.streamsx.topology.tester.Tester;
+import com.ibm.streamsx.topology.spl.SPL;
 
 public class WatsonDeviceEventsTest {
        
     @Test
     public void testDeviceEventsAll() throws Exception {
         
-        Topology topology = new Topology();
+        File iotTkLocation = new File(System.getProperty("streamsx.iot.toolkitlocation"));
         
+        Topology topology = new Topology();
+
+        System.out.printf ("IOT ToolkitLocation used in Topology: %s", iotTkLocation);
+        SPL.addToolkit(topology,iotTkLocation);
+       
         // Generate events, but this test will ignore the device id and type
         // since it is fixed by the deviceCfg.
         JSONObject[] events = DeviceEventsTest.generateEvents(20);


### PR DESCRIPTION
Use addToolkit() to enable variable toolkit location under test in
topology code 

Update build.xml to set STREAMS_SPLPATH to $STREAMS_INSTALL/toolkits for
the forked JVM running the tests. No need anymore to have test
environment to have set STREAMS_SPLPATH.

With these changes the compilation of topology generated SPL uses
STREAMS_SPLPATH for all toolkits IOT depends on and uses the build.xml
provided IOT toolkit under test (local just built, or e.g. the one
delivered with product for regression).