### PR TITLE
Issue#72 use streamsx.mqtt toolkit

### DIFF
--- a/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson.quickstart/quickstart.spl
+++ b/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson.quickstart/quickstart.spl
@@ -7,7 +7,7 @@
 
 use com.ibm.streamsx.iot::* ;
 use com.ibm.streamsx.iot.watson::* ;
-use com.ibm.streamsx.messaging.mqtt::MQTTSource ;
+use com.ibm.streamsx.mqtt::MQTTSource ;
 
 /**
  * Tuple type that matches the Quickstart device simulator event data.

--- a/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson/device.spl
+++ b/com.ibm.streamsx.iot/com.ibm.streamsx.iot.watson/device.spl
@@ -8,8 +8,8 @@ namespace com.ibm.streamsx.iot.watson ;
 use com.ibm.streamsx.iot::*;
 
 use com.ibm.streamsx.json::Json;
-use com.ibm.streamsx.messaging.mqtt::MQTTSource ;
-use com.ibm.streamsx.messaging.mqtt::MQTTSink ;
+use com.ibm.streamsx.mqtt::MQTTSource ;
+use com.ibm.streamsx.mqtt::MQTTSink ;
 
 /**
  * @exclude

--- a/com.ibm.streamsx.iot/info.xml
+++ b/com.ibm.streamsx.iot/info.xml
@@ -15,7 +15,7 @@ a IoT Platform service (including IBM Cloud).
 See [namespace:com.ibm.streamsx.iot] for more details.
 
 This toolkit depends on these toolkits:
-* `com.ibm.streamsx.messaging`
+* `com.ibm.streamsx.mqtt`
 * `com.ibm.streamsx.json` 
 * `com.ibm.streamsx.datetime`
 * `com.ibm.streamsx.topology`
@@ -26,8 +26,8 @@ This toolkit depends on these toolkits:
   </info:identity>
   <info:dependencies>
     <info:toolkit>
-      <common:name>com.ibm.streamsx.messaging</common:name>
-      <common:version>[5.0.0,6.0.0)</common:version>
+      <common:name>com.ibm.streamsx.mqtt</common:name>
+      <common:version>[1.0.0,2.0.0)</common:version>
     </info:toolkit>
     <info:toolkit>
       <common:name>com.ibm.streamsx.json</common:name>


### PR DESCRIPTION
Change of use statements to refer from com.ibm.streamsx.messaging.mqtt to com.ibm.streamsx.mqtt.
Change toolkit dependency in info.xml.

No change on any toolkit user interface. SPL applications doesn't need to be adapted when using this change (new IOT toolkit version).

Change was successfully tested against IOT Service in IBM Cloud.