### PR TITLE
Revert version bump to 1.1.2 -> new bump 1.2.0

### DIFF
--- a/com.ibm.streamsx.iot/info.xml
+++ b/com.ibm.streamsx.iot/info.xml
@@ -21,8 +21,8 @@ This toolkit depends on these toolkits:
 * `com.ibm.streamsx.topology`
 
 </info:description>
-    <info:version>1.1.2</info:version>
-    <info:requiredProductVersion>4.1.0.0</info:requiredProductVersion>
+    <info:version>1.2.0</info:version>
+    <info:requiredProductVersion>4.2.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies>
     <info:toolkit>


### PR DESCRIPTION
As #74 explained, the new product dependency is 4.2.0.
This is to be seen as an interface change, as also the usage of new MQTT toolkit (with exact same operators as old messaging toolkit) can be seen as interface change, the streamsx.iot toolkit version number should be changed in 2nd place and not in 3rd.

This requires deletion of release 1.1.2 and creation of release 1.2.0.